### PR TITLE
Add redis attribute to set ulimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ default["redis"]["client_output_buffer_limit"]  = {
   "pubsub" => "32mb 8mb 60"
 }
 default["redis"]["include_config_files"]        = []
+default["redis"]["ulimit"]                      = ""
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ default["redis"]["ulimit"]                      = ""
 
 ## Basic Settings
 
-None
+* `node["redis"]["ulimit"]` - Sets the maximum number of file descriptors for the Redis process. If this is unset or empty, the limit is the system default. The default may not be high enough to handle a large number of concurrent connections. See [Redis Clients Handling](http://redis.io/topics/clients).
 
 
 ## Contributors

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,3 +57,4 @@ default["redis"]["client_output_buffer_limit"]  = {
   "pubsub" => "32mb 8mb 60"
 }
 default["redis"]["include_config_files"]        = []
+default["redis"]["ulimit"]                      = ""

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -20,3 +20,12 @@ template "/etc/redis/redis.conf" do
   action :create
   notifies :restart, "service[redis-server]"
 end
+
+template "/etc/default/redis-server" do
+  source "default_redis-server.erb"
+  owner  "root"
+  group  "root"
+  mode   "0644"
+  action :create
+  notifies :restart, "service[redis-server]"
+end

--- a/templates/default/default_redis-server.erb
+++ b/templates/default/default_redis-server.erb
@@ -1,0 +1,8 @@
+# redis-server configure options
+
+# ULIMIT: Call ulimit -n with this argument prior to invoking Redis itself.
+# This may be required for high-concurrency environments. Redis itself cannot
+# alter its limits as it is not being run as root. (default: do not call
+# ulimit)
+#
+# ULIMIT=65536

--- a/templates/default/default_redis-server.erb
+++ b/templates/default/default_redis-server.erb
@@ -5,4 +5,8 @@
 # alter its limits as it is not being run as root. (default: do not call
 # ulimit)
 #
+<% if node["redis"]["ulimit"] && !node["redis"]["ulimit"].empty? %>
+ULIMIT=<%= node["redis"]["ulimit"] %>
+<% else %>
 # ULIMIT=65536
+<% end %>


### PR DESCRIPTION
The ulimit for redis can be set in /etc/default/redis-server. This adds an attribute, ulimit, that sets the ulimit setting in that file. If the attribute is unset or empty, the ulimit setting in /etc/default/redis-server file is commented out, which is how the file ships by default.

Changing the ulimit causes the redis-server to restart.

The default ulimit may be too low to handle a large number of clients. See http://redis.io/topics/clients for more information.
