### PR TITLE
Create node["redis"]["dir"]

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -7,6 +7,15 @@ include_recipe "redis::default"
 
 package "redis-server"
 
+directory node[:redis][:dir] do
+  owner "redis"
+  group "redis"
+  mode "0750"
+  action :create
+  recursive true
+end
+
+
 service "redis-server" do
   supports :restart => true
   action [ :enable, :start ]


### PR DESCRIPTION
The cookbook did not create the directory in which Redis stores its files whenever it was set to anything else than the default value.

I've added a small change which corrects this.
